### PR TITLE
Closes sonata-nfv/son-catalogue-repos#28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docker-compose_local.yml
+Gemfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.1
 RUN mkdir -p /app
 COPY Gemfile /app/
 WORKDIR /app
-RUN bundle install --quiet
+RUN bundle install
 COPY . /app
 RUN rake yard
 ENV PORT 4567

--- a/docker-compose_local.yml
+++ b/docker-compose_local.yml
@@ -25,7 +25,7 @@ mongo:
   volumes_from:
     - mongodata
   ports:
-    - "27017:27017"
+    - "27017"
   command: --smallfiles --rest
   restart: always
 

--- a/routes/ns.rb
+++ b/routes/ns.rb
@@ -71,10 +71,9 @@ class SonataNsRepository < Sinatra::Application
 		instance, errors = parse_json(request.body.read)
 		return 400, errors.to_json if errors
 
-		# TODO: Check if same Group, Name, Version do already exists in the database
 		# Retrieve stored version
 		new_nsr = instance
-		
+
 		begin
 			nsr = Nsr.find_by( { "_id" =>  params[:id] })
 			puts 'NS is found'
@@ -83,13 +82,12 @@ class SonataNsRepository < Sinatra::Application
 		end
 
 		# Update to new version
-		nsr = {}
 		puts 'Updating...'
-		new_nsr['_id'] = SecureRandom.uuid
-		nsr = new_nsr # TODO: Avoid having multiple 'nsd' fields containers
-
 		begin
-			new_nsr = Nsr.create!(nsr)
+			#Delete old record
+			Nsr.where( { "_id" => params[:id] }).delete
+			#Create a record
+			new_nsr = Nsr.create!(instance)
 		rescue Moped::Errors::OperationFailure => e
 			return 400, 'ERROR: Duplicated NS ID' if e.message.include? 'E11000'
 		end
@@ -98,8 +96,5 @@ class SonataNsRepository < Sinatra::Application
 		return 200, nsr_json
 		#return 200, new_ns.to_json
 	end
-
-
-
 
 end


### PR DESCRIPTION
The PUT method for /records/nsr/ns-instances/:id Delete the old record and create a new one keeping the UUID
