### PR TITLE
Limit of returned descriptors increased

### DIFF
--- a/routes/catalogue_routes.rb
+++ b/routes/catalogue_routes.rb
@@ -102,7 +102,7 @@ class SonataCatalogue < Sinatra::Application
 	# -> List all NSs in JSON or YAML format
 	get '/network-services' do
 		params[:offset] ||= 1
-		params[:limit] ||= 10
+		params[:limit] ||= 50
 
 		# Only accept positive numbers
 		params[:offset] = 1 if params[:offset].to_i < 1
@@ -762,7 +762,7 @@ class SonataCatalogue < Sinatra::Application
 	# List all VNFs in JSON or YAML format
 	get '/vnfs' do
 		params[:offset] ||= 1
-		params[:limit] ||= 2
+		params[:limit] ||= 50
 
 		# Only accept positive numbers
 		params[:offset] = 1 if params[:offset].to_i < 1
@@ -1393,7 +1393,7 @@ class SonataCatalogue < Sinatra::Application
 	# List all Packages in JSON or YAML format
 	get '/packages' do
 		params[:offset] ||= 1
-		params[:limit] ||= 10
+		params[:limit] ||= 50
 
 		# Only accept positive numbers
 		params[:offset] = 1 if params[:offset].to_i < 1


### PR DESCRIPTION
Limit of Descriptors returned has been increased to 50
Now NSD/VNFD APIs have a return limit of 50 Descriptors for a list-all query due to pagination of items
This limit can be increased, or removed (no link header)
Package Descriptors don't have limit applied
