### PR TITLE
Added rake task to fill empty Catalogues. Added sample files...

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ curl -X GET http://localhost:4011/records/vnfr/9f18bc1b-b18d-483b-88da-a600e9255
 
 You can use mongoexpress to manage the mongo databases.
 
+### Pushing 'sonata-demo' files to Catalogues
+
+The Rakefile in root folder includes an specific task to fill the Catalogues with descriptor sample files from
+sonata-demo package. This is specially useful when starting an empty Catalogue. It can be run with a rake task:
+
+```sh
+rake init:load_samples
+```
 
 ### API Documentation
 

--- a/Rakefile
+++ b/Rakefile
@@ -31,3 +31,22 @@ namespace :db do
     require './main'
   end
 end
+
+namespace :init do
+  require 'fileutils'
+  desc "Fill Catalogues with default sonata-demo package contents"
+  task :load_samples do
+    firewall_sample = "samples/sonata-demo/function-descriptor/firewall-vnfd.yml"
+    iperf_sample = "samples/sonata-demo/function-descriptor/iperf-vnfd.yml"
+    tcpdump_sample = "samples/sonata-demo/function-descriptor/tcpdump-vnfd.yml"
+    nsd_sample = "samples/sonata-demo/service-descriptor/sonata-demo.yml"
+    pd_sample = "samples/sonata-demo/package-descriptor/sonata-demo.yml"
+
+    sh "curl -X POST -H \"Content-Type: application/x-yaml\" --data-binary @#{ firewall_sample } --connect-timeout 30 http://sp.int.sonata-nfv.eu:4002/catalogues/vnfs"
+    sh "curl -X POST -H \"Content-Type: application/x-yaml\" --data-binary @#{ iperf_sample } --connect-timeout 30 http://sp.int.sonata-nfv.eu:4002/catalogues/vnfs"
+    sh "curl -X POST -H \"Content-Type: application/x-yaml\" --data-binary @#{ tcpdump_sample } --connect-timeout 30 http://sp.int.sonata-nfv.eu:4002/catalogues/vnfs"
+    sh "curl -X POST -H \"Content-Type: application/x-yaml\" --data-binary @#{ nsd_sample } --connect-timeout 30 http://sp.int.sonata-nfv.eu:4002/catalogues/network-services"
+    sh "curl -X POST -H \"Content-Type: application/x-yaml\" --data-binary @#{ pd_sample } --connect-timeout 30 http://sp.int.sonata-nfv.eu:4002/catalogues/packages"
+  end
+
+end

--- a/samples/sonata-demo/function-descriptor/firewall-vnfd.yml
+++ b/samples/sonata-demo/function-descriptor/firewall-vnfd.yml
@@ -1,0 +1,73 @@
+# YAML description of a firewall docker container
+# used in the SONATA platform
+
+---
+##
+## Some general information regarding this
+## VNF descriptor.
+##
+descriptor_version: "vnfd-schema-01"
+
+vendor: "eu.sonata-nfv"
+name: "firewall-vnf"
+version: "0.2"
+author: "Steven van Rossem, iMinds"
+description: >
+  "A first firewall VNF descriptor"
+
+##
+## The virtual deployment unit.
+##
+virtual_deployment_units:
+  - id: "vdu01"
+    vm_image: "file:///docker_files/firewall/Dockerfile"
+    vm_image_format: "docker"
+    resource_requirements:
+      cpu:
+        vcpus: 1
+      memory:
+        size: 2
+        size_unit: "GB"
+      storage:
+        size: 10
+        size_unit: "GB"
+    connection_points:
+      - id: "vdu01:cp01"
+        type: "interface"
+      - id: "vdu01:cp02"
+        type: "interface"
+      - id: "vdu01:cp03"
+        type: "interface"
+
+##
+## The virtual links that interconnect
+## the different connections points.
+##
+virtual_links:
+  - id: "mgmt"
+    connectivity_type: "E-LAN"
+    connection_points_reference:
+      - "vdu01:cp01"
+      - "vnf:mgmt"
+  - id: "input"
+    connectivity_type: "E-Line"
+    connection_points_reference:
+      - "vdu01:cp02"
+      - "vnf:input"
+  - id: "output"
+    connectivity_type: "E-Line"
+    connection_points_reference:
+      - "vdu01:cp03"
+      - "vnf:output"
+
+##
+## The VNF connection points to the
+## outside world.
+##
+connection_points:
+  - id: "vnf:mgmt"
+    type: "interface"
+  - id: "vnf:input"
+    type: "interface"
+  - id: "vnf:output"
+    type: "interface"

--- a/samples/sonata-demo/function-descriptor/iperf-vnfd.yml
+++ b/samples/sonata-demo/function-descriptor/iperf-vnfd.yml
@@ -1,0 +1,74 @@
+# YAML description of a iperf docker container
+# used in the SONATA platform
+
+---
+##
+## Some general information regarding this
+## VNF descriptor.
+##
+descriptor_version: "vnfd-schema-01"
+
+vendor: "eu.sonata-nfv"
+name: "iperf-vnf"
+version: "0.2"
+author: "Steven van Rossem, iMinds"
+description: >
+  "A first iperf VNF descriptor. The iperf VNF
+   acts as a traffic source."
+
+##
+## The virtual deployment unit.
+##
+virtual_deployment_units:
+  - id: "vdu01"
+    vm_image: "file:///docker_files/iperf/Dockerfile"
+    vm_image_format: "docker"
+    resource_requirements:
+      cpu:
+        vcpus: 1
+      memory:
+        size: 2
+        size_unit: "GB"
+      storage:
+        size: 10
+        size_unit: "GB"
+    connection_points:
+      - id: "vdu01:cp01"
+        type: "interface"
+      - id: "vdu01:cp02"
+        type: "interface"
+      - id: "vdu01:cp03"
+        type: "interface"
+
+##
+## The virtual links that interconnect
+## the different connections points.
+##
+virtual_links:
+  - id: "mgmt"
+    connectivity_type: "E-LAN"
+    connection_points_reference:
+      - "vdu01:cp01"
+      - "vnf:mgmt"
+  - id: "input"
+    connectivity_type: "E-Line"
+    connection_points_reference:
+      - "vdu01:cp02"
+      - "vnf:input"
+  - id: "output"
+    connectivity_type: "E-Line"
+    connection_points_reference:
+      - "vdu01:cp03"
+      - "vnf:output"
+
+##
+## The VNF connection points to the
+## outside world.
+##
+connection_points:
+  - id: "vnf:mgmt"
+    type: "interface"
+  - id: "vnf:input"
+    type: "interface"
+  - id: "vnf:output"
+    type: "interface"

--- a/samples/sonata-demo/function-descriptor/tcpdump-vnfd.yml
+++ b/samples/sonata-demo/function-descriptor/tcpdump-vnfd.yml
@@ -1,0 +1,74 @@
+# YAML description of a tcpdump docker container
+# used in the SONATA platform
+
+---
+##
+## Some general information regarding this
+## VNF descriptor.
+##
+descriptor_version: "vnfd-schema-01"
+
+vendor: "eu.sonata-nfv"
+name: "tcpdump-vnf"
+version: "0.2"
+author: "Steven van Rossem, iMinds"
+description: >
+  "A first tcpdump VNF descriptor. The tcpdump
+   VNF acts as a traffic sink."
+
+##
+## The virtual deployment unit.
+##
+virtual_deployment_units:
+  - id: "vdu01"
+    vm_image: "file:///docker_files/tcpdump/Dockerfile"
+    vm_image_format: "docker"
+    resource_requirements:
+      cpu:
+        vcpus: 1
+      memory:
+        size: 2
+        size_unit: "GB"
+      storage:
+        size: 10
+        size_unit: "GB"
+    connection_points:
+      - id: "vdu01:cp01"
+        type: "interface"
+      - id: "vdu01:cp02"
+        type: "interface"
+      - id: "vdu01:cp03"
+        type: "interface"
+
+##
+## The virtual links that interconnect
+## the different connections points.
+##
+virtual_links:
+  - id: "mgmt"
+    connectivity_type: "E-LAN"
+    connection_points_reference:
+      - "vdu01:cp01"
+      - "vnf:mgmt"
+  - id: "input"
+    connectivity_type: "E-Line"
+    connection_points_reference:
+      - "vdu01:cp02"
+      - "vnf:input"
+  - id: "output"
+    connectivity_type: "E-Line"
+    connection_points_reference:
+      - "vdu01:cp03"
+      - "vnf:output"
+
+##
+## The VNF connection points to the
+## outside world.
+##
+connection_points:
+  - id: "vnf:mgmt"
+    type: "interface"
+  - id: "vnf:input"
+    type: "interface"
+  - id: "vnf:output"
+    type: "interface"

--- a/samples/sonata-demo/package-descriptor/sonata-demo.yml
+++ b/samples/sonata-demo/package-descriptor/sonata-demo.yml
@@ -1,0 +1,78 @@
+##
+## This example is a moderatly complex package
+## descriptor. It only contains mandatory and
+## optional fields.
+##
+## @author Michael Bredel
+##
+---
+descriptor_version: "1.0"
+
+vendor: "eu.sonata-nfv.package"
+name: "sonata-demo"
+version: "0.2"
+package_maintainer: "Michael Bredel, NEC Labs Europe"
+package_description: >
+  "The package descriptor for the SONATA demo package that
+   comprises the descritors of the demo network service,
+   the related VNFs, as well as the virtual machine
+   images (or docker files) to instantiate the service."
+
+entry_service_template: "/service_descriptors/sonata-demo.yml"
+sealed: true
+
+package_content:
+  - name: "/service_descriptors/sonata-demo.yml"
+    content-type: "application/sonata.service_descriptor"
+    md5: "122746ec8e29774770c66ef210157931"
+  - name: "/function_descriptors/iperf-vnfd.yml"
+    content-type: "application/sonata.function_descriptor"
+    md5: "75a512a20b9cce424e5e6f0d07544e74"
+  - name: "/function_descriptors/firewall-vnfd.yml"
+    content-type: "application/sonata.function_descriptor"
+    md5: "e25665f687ec894dbbe7a5b0f0beca42"
+  - name: "/function_descriptors/tcpdump-vnfd.yml"
+    content-type: "application/sonata.function_descriptor"
+    md5: "c1328a8ab1802eac0f1ee0458c80c21e"
+  - name: "/docker_files/iperf/Dockerfile"
+    content-type: "application/sonata.docker_files"
+    md5: "5bea7b1f2f73803946674adecaaa9246"
+  - name: "/docker_files/iperf/start.sh"
+    content-type: "application/x-sh"
+    md5: "5db937fdadb488559eb765b64efcf8c4"
+  - name: "/docker_files/firewall/Dockerfile"
+    content-type: "application/sonata.docker_files"
+    md5: "fed89e35d173e6aeaf313e1a9ab3f552"
+  - name: "/docker_files/firewall/start.sh"
+    content-type: "application/x-sh"
+    md5: "17d604d460b8768ac7277ba8ae65be4b"
+  - name: "/docker_files/tcpdump/Dockerfile"
+    content-type: "application/sonata.docker_files"
+    md5: "e0d2bb965744161ffb0f8af459a589e3"
+  - name: "/docker_files/tcpdump/start.sh"
+    content-type: "application/x-sh"
+    md5: "95fd94539c7ceb2fbcce8e24dc30b6ba"
+
+# Not used in this demo.
+#
+#package_resolvers:
+#  - name: "http://www.bredel-it.de/path/to/catalog"
+#    credentials:
+#      username: "username"
+#      password: "password"
+#
+#package_dependencies:
+# - name: "my-dependent-package"
+#   group: "eu.sonata.nfv"
+#   version: "1.0"
+#   credentials: "my credentials"
+
+artifact_dependencies:
+  # This could be the vm image that runs the docker environment.
+  # It is a dummy right now.
+  - name: "my-vm-image"
+    url: "http://www.bredel-it.de/path/to/vm-image"
+    md5: "00236a2ae558018ed13b5222ef1bd9f3"
+    credentials:
+      username: "username"
+      password: "password"

--- a/samples/sonata-demo/service-descriptor/sonata-demo.yml
+++ b/samples/sonata-demo/service-descriptor/sonata-demo.yml
@@ -1,0 +1,113 @@
+##
+## This is the network service descriptor of the
+## SONATA demo example that comprises a traffic
+## source, namely iperf, a firewall, and a traffic
+## sink, namely tcpdump.
+##
+## @author Michael Bredel
+##
+---
+descriptor_version: "1.0"
+
+vendor: "eu.sonata-nfv.service-descriptor"
+name: "sonata-demo"
+version: "0.2"
+author: "Michael Bredel, NEC Labs Europe"
+description: >
+  "The network service descriptor for the SONATA demo,
+   comprising iperf, a firewall, and tcpump."
+
+##
+## The various network functions this service
+## is composed of.
+##
+network_functions:
+  - vnf_id: "vnf_firewall"
+    vnf_vendor: "eu.sonata-nfv"
+    vnf_name: "firewall-vnf"
+    vnf_version: "0.1"
+  - vnf_id: "vnf_iperf"
+    vnf_vendor: "eu.sonata-nfv"
+    vnf_name: "iperf-vnf"
+    vnf_version: "0.1"
+  - vnf_id: "vnf_tcpdump"
+    vnf_vendor: "eu.sonata-nfv"
+    vnf_name: "tcpdump-vnf"
+    vnf_version: "0.1"
+
+##
+## The NS connection points to the
+## outside world.
+##
+connection_points:
+  - id: "ns:mgmt"
+    type: "interface"
+  - id: "ns:input"
+    type: "interface"
+  - id: "ns:output"
+    type: "interface"
+
+##
+## The virtual links that interconnect
+## the different connections points.
+##
+virtual_links:
+  - id: "mgmt"
+    connectivity_type: "E-LAN"
+    connection_points_reference:
+      - "vnf_iperf:mgmt"
+      - "vnf_firewall:mgmt"
+      - "vnf_tcpdump:mgmt"
+      - "ns:mgmt"
+  - id: "input-2-iperf"
+    connectivity_type: "E-Line"
+    connection_points_reference:
+      - "ns:input"
+      - "vnf_iperf:input"
+  - id: "iperf-2-firewall"
+    connectivity_type: "E-Line"
+    connection_points_reference:
+      - "vnf_iperf:output"
+      - "vns_firewall:input"
+  - id: "firewall-2-tcpdump"
+    connectivity_type: "E-Line"
+    connection_points_reference:
+      - "vns_firewall:output"
+      - "vnf_tcpdump:input"
+  - id: "tcpdump-2-output"
+    connectivity_type: "E-Line"
+    connection_points_reference:
+      - "vnf_firewall:output"
+      - "ns:output"
+
+##
+## The forwarding graphs.
+##
+forwarding_graphs:
+  - fg_id: "ns:fg01"
+    number_of_endpoints: 2
+    number_of_virtual_links: 4
+    constituent_vnfs:
+      - "vnf_iperf"
+      - "vnf_firewall"
+      - "vnf_tcpdump"
+    network_forwarding_paths:
+      - fp_id: "ns:fg01:fp01"
+        policy: "none"
+        connection_points:
+          - connection_point_ref: "ns:input"
+            position: 1
+          - connection_point_ref: "vnf_iperf:input"
+            position: 2
+          - connection_point_ref: "vnf_iperf:output"
+            position: 3
+          - connection_point_ref: "vnf_firewall:input"
+            position: 4
+          - connection_point_ref: "vnf_firewall:output"
+            position: 5
+          - connection_point_ref: "vnf_tcpdump:input"
+            position: 6
+          - connection_point_ref: "vnf_tcpdump:output"
+            position: 7
+          - connection_point_ref: "ns:output"
+            position: 8


### PR DESCRIPTION
Updated README file:
The Rakefile in root folder includes an specific task to fill the Catalogues with descriptor sample files from sonata-demo package. This is specially useful when starting an empty Catalogue. It can be run with a rake task:
$ rake init:load_samples
